### PR TITLE
fix: remove docker login

### DIFF
--- a/.github/workflows/test-image.yaml
+++ b/.github/workflows/test-image.yaml
@@ -16,12 +16,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-      - name: Login to DockerHub
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Get Tags for cloud-platform-port-forward-docker-image
         id: metadata
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0


### PR DESCRIPTION
## Purpose

- Dependabot doesn't have access to secrets so it fails - remove docker login